### PR TITLE
Fix CICD workflow issues present in project skeleton

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,18 @@ jobs:
 
       matrix:
         packages:
-          - {os: "ubuntu-latest", package: "sdist"}
-          - {os: "ubuntu-latest", package: "wheel"}
+          - {os: "ubuntu-latest", python-version: "3.12", package: "sdist"}
+          - {os: "ubuntu-latest", python-version: "3.12", package: "wheel"}
 
     steps:
       - name: checkout repo
         uses: actions/checkout@v4
+
+      - name: install python${{ matrix.python-version }}
+        id: install-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: setup
         run: scripts/setup

--- a/scripts/activate
+++ b/scripts/activate
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+    source ".venv/Scripts/activate"
+else
+    source ".venv/bin/activate"
+fi

--- a/scripts/fmt
+++ b/scripts/fmt
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-source .venv/bin/activate
+source scripts/activate
 icebreaker fmt

--- a/scripts/package-sdist
+++ b/scripts/package-sdist
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-source .venv/bin/activate
+source scripts/activate
 rm -rf dist
 cp version src/icebreaker
 python -m build --sdist

--- a/scripts/package-wheel
+++ b/scripts/package-wheel
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-source .venv/bin/activate
+source scripts/activate
 rm -rf dist
 cp version src/icebreaker
 python -m build --wheel

--- a/scripts/publish-sdist
+++ b/scripts/publish-sdist
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-source .venv/bin/activate
+source scripts/activate
 VERSION=$(cat version)
 twine upload -r testpypi "dist/arktika-icebreaker-${VERSION}.tar.gz"

--- a/scripts/publish-wheel
+++ b/scripts/publish-wheel
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-source .venv/bin/activate
+source scripts/activate
 VERSION=$(cat version)
 twine upload -r testpypi "dist/arktika-icebreaker-${VERSION}.whl"

--- a/scripts/setup
+++ b/scripts/setup
@@ -3,6 +3,6 @@
 set -euo pipefail
 
 python -m venv --copies --clear --upgrade-deps ".venv"
-source ".venv/bin/activate"
+source scripts/activate
 python -m pip install --upgrade pip setuptools wheel
 python -m pip install --editable ".[dev,cli,testing,aws]"

--- a/scripts/test-acceptance
+++ b/scripts/test-acceptance
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-source .venv/bin/activate
+source scripts/activate
 pytest -vv -ra --strict-markers --strict-config --durations 10 --new-first --basetemp .test_artifacts --asyncio-mode auto tests/acceptance

--- a/scripts/test-functional
+++ b/scripts/test-functional
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-source .venv/bin/activate
+source scripts/activate
 pytest -vv -ra --strict-markers --strict-config --durations 10 --new-first --basetemp .test_artifacts --asyncio-mode auto tests/functional

--- a/scripts/test-performance
+++ b/scripts/test-performance
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-source .venv/bin/activate
+source scripts/activate
 pytest -vv -ra --strict-markers --strict-config --durations 10 --new-first --basetemp .test_artifacts --asyncio-mode auto tests/performance

--- a/scripts/test-property
+++ b/scripts/test-property
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-source .venv/bin/activate
+source scripts/activate
 pytest -vv -ra --strict-markers --strict-config --durations 10 --new-first --basetemp .test_artifacts --asyncio-mode auto tests/property

--- a/scripts/test-security
+++ b/scripts/test-security
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-source .venv/bin/activate
+source scripts/activate
 pytest -vv -ra --strict-markers --strict-config --durations 10 --new-first --basetemp .test_artifacts --asyncio-mode auto tests/security

--- a/scripts/test-smoke
+++ b/scripts/test-smoke
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-source .venv/bin/activate
+source scripts/activate
 pytest -vv -ra --strict-markers --strict-config --durations 10 --new-first --basetemp .test_artifacts --asyncio-mode auto tests/smoke

--- a/scripts/test-unit
+++ b/scripts/test-unit
@@ -2,5 +2,5 @@
 
 set -euo pipefail
 
-source .venv/bin/activate
+source scripts/activate
 pytest -vv -ra --strict-markers --strict-config --durations 10 --new-first --basetemp .test_artifacts --asyncio-mode auto tests/unit


### PR DESCRIPTION
1. Scripts were using `.venv/bin/activate` on Windows, which is incorrect as the activate script sits under `.venv/Scripts/activate`. Added a custom `activate` script that deals with that descrepency.
2. Release workflow was using default python present on the OS, rather than 3.12. Added a job step to install correct python.