### PR TITLE
Implement pre-packaged type testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ cli = [
 ]
 
 testing = [
-    "ruff==0.*"
+    "ruff==0.*",
+    "mypy==1.*"
 ]
 
 [project.scripts]

--- a/src/icebreaker/_internal/code_quality/__init__.py
+++ b/src/icebreaker/_internal/code_quality/__init__.py
@@ -4,3 +4,5 @@ from icebreaker._internal.code_quality._formatter import Success as Success
 from icebreaker._internal.code_quality._formatter import Report as Report
 from icebreaker._internal.code_quality._formatter import CheckReport as CheckReport
 from icebreaker._internal.code_quality._formatter import FormatReport as FormatReport
+from icebreaker._internal.code_quality._type_checker import TypeChecker as TypeChecker
+from icebreaker._internal.code_quality._mypy_type_checker import MypyTypeChecker as MypyTypeChecker

--- a/src/icebreaker/_internal/code_quality/_formatter.py
+++ b/src/icebreaker/_internal/code_quality/_formatter.py
@@ -1,5 +1,6 @@
 from typing import Self
 from typing import TypeAlias
+from typing import Protocol
 from pathlib import Path
 
 Success: TypeAlias = bool
@@ -8,7 +9,7 @@ CheckReport: TypeAlias = tuple[Success, Report]
 FormatReport: TypeAlias = tuple[Success, Report]
 
 
-class Formatter:
+class Formatter(Protocol):
     dependencies_are_installed: bool
 
     def format(

--- a/src/icebreaker/_internal/code_quality/_formatter.py
+++ b/src/icebreaker/_internal/code_quality/_formatter.py
@@ -10,7 +10,8 @@ FormatReport: TypeAlias = tuple[Success, Report]
 
 
 class Formatter(Protocol):
-    dependencies_are_installed: bool
+    @property
+    def dependencies_are_installed(self: Self) -> bool: ...
 
     def format(
         self: Self,

--- a/src/icebreaker/_internal/code_quality/_mypy_type_checker.py
+++ b/src/icebreaker/_internal/code_quality/_mypy_type_checker.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Final
+from typing import Self
+
+from icebreaker._internal.code_quality._formatter import CheckReport
+
+
+class MypyTypeChecker:
+    MYPY_CONFIG: Final[list[str]] = [
+        "--strict",
+        "--warn-unreachable",
+        "--extra-checks",
+    ]
+
+    def __init__(
+        self: Self,
+        mypy_binary_name: str = "mypy",
+    ) -> None:
+        self.mypy_binary_name = mypy_binary_name
+
+    @property
+    def dependencies_are_installed(self: Self) -> bool:
+        return bool(shutil.which(self.mypy_binary_name))
+
+    def _error_if_dependencies_are_not_installed(self: Self) -> None:
+        if not self.dependencies_are_installed:
+            raise FileNotFoundError(f'"{self.mypy_binary_name}" not found.')
+
+    def check(
+        self: Self,
+        target: Path,
+    ) -> CheckReport:
+        self._error_if_dependencies_are_not_installed()
+
+        args: list[str] = [self.mypy_binary_name, str(target)]
+        for config in self.MYPY_CONFIG:
+            args.append(config)
+
+        result = subprocess.run(args, check=False, capture_output=True)
+        report = "\n".join([result.stdout.decode("utf-8"), result.stderr.decode("utf-8")])
+        if result.returncode == 0:
+            return True, report
+        return False, report

--- a/src/icebreaker/_internal/code_quality/_type_checker.py
+++ b/src/icebreaker/_internal/code_quality/_type_checker.py
@@ -9,7 +9,8 @@ CheckReport: TypeAlias = tuple[Success, Report]
 
 
 class TypeChecker(Protocol):
-    dependencies_are_installed: bool
+    @property
+    def dependencies_are_installed(self: Self) -> bool: ...
 
     def check(
         self: Self,

--- a/src/icebreaker/_internal/code_quality/_type_checker.py
+++ b/src/icebreaker/_internal/code_quality/_type_checker.py
@@ -1,5 +1,6 @@
 from typing import Self
 from typing import TypeAlias
+from typing import Protocol
 from pathlib import Path
 
 Success: TypeAlias = bool
@@ -7,7 +8,7 @@ Report: TypeAlias = str
 CheckReport: TypeAlias = tuple[Success, Report]
 
 
-class TypeChecker:
+class TypeChecker(Protocol):
     dependencies_are_installed: bool
 
     def check(

--- a/src/icebreaker/_internal/code_quality/_type_checker.py
+++ b/src/icebreaker/_internal/code_quality/_type_checker.py
@@ -1,0 +1,16 @@
+from typing import Self
+from typing import TypeAlias
+from pathlib import Path
+
+Success: TypeAlias = bool
+Report: TypeAlias = str
+CheckReport: TypeAlias = tuple[Success, Report]
+
+
+class TypeChecker:
+    dependencies_are_installed: bool
+
+    def check(
+        self: Self,
+        target: Path,
+    ) -> CheckReport: ...

--- a/src/icebreaker/testing/__init__.py
+++ b/src/icebreaker/testing/__init__.py
@@ -1,1 +1,2 @@
 from icebreaker.testing._test_code_formatting import TestCodeFormatting as TestCodeFormatting
+from icebreaker.testing._test_code_typing import TestCodeTyping as TestCodeTyping

--- a/src/icebreaker/testing/_test_code_formatting.py
+++ b/src/icebreaker/testing/_test_code_formatting.py
@@ -1,8 +1,8 @@
 from typing import Self
 from pathlib import Path
 
-from icebreaker._internal.code_quality import RuffFormatter as RuffFormatter
-from icebreaker._internal.code_quality import Formatter as Formatter
+from icebreaker._internal.code_quality import RuffFormatter
+from icebreaker._internal.code_quality import Formatter
 
 
 class TestCodeFormatting:
@@ -13,7 +13,7 @@ class TestCodeFormatting:
 Please install testing dependencies using "pip install arktika-icebreaker[testing]"."""
 
         code_is_formatted, report = self.formatter.check(target=Path.cwd())
-        assert code_is_formatted, f"""Formatting issues found. 
+        assert code_is_formatted, f"""Formatting issues detected. 
 
 {report}
 

--- a/src/icebreaker/testing/_test_code_typing.py
+++ b/src/icebreaker/testing/_test_code_typing.py
@@ -1,0 +1,18 @@
+from typing import Self
+from pathlib import Path
+
+from icebreaker._internal.code_quality import MypyTypeChecker
+from icebreaker._internal.code_quality import TypeChecker
+
+
+class TestCodeTyping:
+    type_checker: TypeChecker = MypyTypeChecker()
+
+    def test_code_is_correctly_typed(self: Self) -> None:
+        assert self.type_checker.dependencies_are_installed, """Missing testing dependencies.
+Please install testing dependencies using "pip install arktika-icebreaker[testing]"."""
+
+        code_is_correctly_typed, report = self.type_checker.check(target=Path.cwd())
+        assert code_is_correctly_typed, f"""Typing issues detected.
+
+{report}"""

--- a/src/icebreaker/versioning/_version_file_based.py
+++ b/src/icebreaker/versioning/_version_file_based.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 from types import ModuleType
 from typing import Self
+from types import FrameType
 
 
 class VersionFileBased:
@@ -65,7 +66,7 @@ class VersionFileBased:
         # 1st position will be self.resolve_version calling this function
         # 2nd position will be the function calling us
         calling_module_frame: FrameInfo = stack[2]
-        calling_module_name: str = calling_module_frame[0]
+        calling_module_name: FrameType = calling_module_frame[0]
         calling_module: ModuleType | None = inspect.getmodule(calling_module_name)
         if not calling_module or not calling_module.__file__:
             raise ModuleNotFoundError("Could not discover calling module.")

--- a/tests/acceptance/tests/test_code_style.py
+++ b/tests/acceptance/tests/test_code_style.py
@@ -1,1 +1,2 @@
 from icebreaker.testing import TestCodeFormatting as TestCodeFormatting
+from icebreaker.testing import TestCodeTyping as TestCodeTyping

--- a/tests/smoke/tests/test_cli.py
+++ b/tests/smoke/tests/test_cli.py
@@ -7,9 +7,19 @@ from icebreaker import __version__
 
 class TestCLIVersion:
     def test_returns_expected_output(self: Self) -> None:
-        output: CompletedProcess = subprocess.run(["icebreaker", "version"], check=True, text=True, capture_output=True)
+        output: CompletedProcess[str] = subprocess.run(
+            ["icebreaker", "version"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
         assert output.stdout == __version__
 
     def test_returns_expected_status_code(self: Self) -> None:
-        output: CompletedProcess = subprocess.run(["icebreaker", "version"], check=True, text=True, capture_output=True)
+        output: CompletedProcess[str] = subprocess.run(
+            ["icebreaker", "version"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
         assert output.returncode == 0


### PR DESCRIPTION
The user can now import `from icebreaker.testing import TestCodeTyping` which will validate that their codebase is correctly typed.
In that fashion, this PR also adds the pre-packaged test into the acceptance test suite of this project.
Additionally, the resulting discovered type errors have been addressed.