### PR TITLE
Rework `fmt --check` to be under `fmt check` instead

### DIFF
--- a/src/icebreaker/_cli/commands/fmt_check.py
+++ b/src/icebreaker/_cli/commands/fmt_check.py
@@ -6,7 +6,7 @@ from icebreaker._cli.interfaces import Printer
 from icebreaker._internal.formatting import Formatter
 
 
-class Fmt:
+class FmtCheck:
     printer: Printer
     error_printer: Printer
     formatter: Formatter
@@ -32,7 +32,7 @@ class Fmt:
             )
             return ExitCode(1)
 
-        success, report = self.formatter.format(target=target)
+        success, report = self.formatter.check(target=target)
 
         if not success:
             self.error_printer(report)


### PR DESCRIPTION
So the CLI now looks like this;
```
usage: icebreaker fmt [-h] [--target TARGET] {check} ...

Format the codebase.

options:
  -h, --help       show this help message and exit
  --target TARGET

subcommands:
  {check}
```

This has a backwards-incompatible change of how we set a custom target.
Where as before it was a positional argument, it is now an option.